### PR TITLE
EX-2465 Handle `null` in text functions; remove bessel

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,18 +17,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 Other libraries included:
 
-BESSELI, BESSELJ, BESSELK, BESSELY functions:
-
-Copyright (c) 2013 SheetJS
-
-The MIT License (MIT)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 jStat - JavaScript Statistical Library:
 
 Copyright (c) 2013 jStat

--- a/lib/engineering.js
+++ b/lib/engineering.js
@@ -2,51 +2,10 @@ var error = require('./error');
 var jStat = require('jStat').jStat;
 var text = require('./text');
 var utils = require('./utils');
-var bessel = require('bessel');
 
 function isValidBinaryNumber(number) {
   return (/^[01]{1,10}$/).test(number);
 }
-
-exports.BESSELI = function(x, n) {
-  x = utils.parseNumber(x);
-  n = utils.parseNumber(n);
-  if (utils.anyIsError(x, n)) {
-    return error.value;
-  }
-
-  return bessel.besseli(x, n);
-};
-
-exports.BESSELJ = function(x, n) {
-  x = utils.parseNumber(x);
-  n = utils.parseNumber(n);
-  if (utils.anyIsError(x, n)) {
-    return error.value;
-  }
-
-  return bessel.besselj(x, n);
-};
-
-exports.BESSELK = function(x, n) {
-  x = utils.parseNumber(x);
-  n = utils.parseNumber(n);
-  if (utils.anyIsError(x, n)) {
-    return error.value;
-  }
-
-  return bessel.besselk(x, n);
-};
-
-exports.BESSELY = function(x, n) {
-  x = utils.parseNumber(x);
-  n = utils.parseNumber(n);
-  if (utils.anyIsError(x, n)) {
-    return error.value;
-  }
-
-  return bessel.bessely(x, n);
-};
 
 exports.BIN2DEC = function(number) {
   // Return error if number is not binary or contains more than 10 characters (10 digits)

--- a/lib/math-trig.js
+++ b/lib/math-trig.js
@@ -115,6 +115,9 @@ exports.AGGREGATE = function(function_num, options, ref1, ref2) {
 };
 
 exports.ARABIC = function(text) {
+  if (text === null) {
+    return error.na;
+  }
   // Credits: Rafa? Kukawski
   if (!/^M*(?:D?C{0,3}|C[MD])(?:L?X{0,3}|X[CL])(?:V?I{0,3}|I[XV])$/.test(text)) {
     return error.value;

--- a/lib/text.js
+++ b/lib/text.js
@@ -86,7 +86,7 @@ exports.EXACT = function(text1, text2) {
 };
 
 exports.FIND = function(find_text, within_text, position) {
-  if (arguments.length < 2) {
+  if (arguments.length < 2 || utils.anyIsNull(find_text, within_text)) {
     return error.na;
   }
   position = (position === undefined) ? 0 : position;
@@ -145,11 +145,15 @@ exports.LEN = function(text) {
     return error.error;
   }
 
+  if (text === null) {
+    return error.na;
+  }
+
   if (typeof text === 'string') {
     return text ? text.length : 0;
   }
 
-  if (text.length) {
+  if (text.length !== undefined) {
     return text.length;
   }
 
@@ -157,6 +161,9 @@ exports.LEN = function(text) {
 };
 
 exports.LOWER = function(text) {
+  if (text === null) {
+    return error.na;
+  }
   if (typeof text !== 'string') {
     return error.value;
   }
@@ -178,6 +185,13 @@ exports.MID = function(text, start, number) {
 
 // TODO
 exports.NUMBERVALUE = function (text, decimal_separator, group_separator)  {
+  if (text === null) {
+    return error.na;
+  }
+  if (utils.anyIsError(decimal_separator, group_separator) || typeof text !== 'string') {
+    return error.value;
+  }
+
   decimal_separator = (typeof decimal_separator === 'undefined') ? '.' : decimal_separator;
   group_separator = (typeof group_separator === 'undefined') ? ',' : group_separator;
   return Number(text.replace(decimal_separator, '.').replace(group_separator, ''));
@@ -189,6 +203,9 @@ exports.PRONETIC = function() {
 };
 
 exports.PROPER = function(text) {
+  if (text === null) {
+    return error.na;
+  }
   if (text === undefined || text.length === 0) {
     return error.value;
   }
@@ -211,29 +228,46 @@ exports.PROPER = function(text) {
 };
 
 exports.REGEXEXTRACT = function (text, regular_expression) {
-  if (arguments.length < 2) {
+  if (arguments.length < 2 || utils.anyIsNull(text, regular_expression)) {
     return error.na;
   }
+  if (typeof text !== 'string') {
+    return error.value;
+  }
+
   var match = text.match(new RegExp(regular_expression));
   return match ? (match[match.length > 1 ? match.length - 1 : 0]) : null;
 };
 
 exports.REGEXMATCH = function (text, regular_expression, full) {
-  if (arguments.length < 2) {
+  if (arguments.length < 2 || utils.anyIsNull(text, regular_expression)) {
     return error.na;
   }
+  if (typeof text !== 'string') {
+    return error.value;
+  }
+
   var match = text.match(new RegExp(regular_expression));
   return full ? match : !!match;
 };
 
 exports.REGEXREPLACE = function (text, regular_expression, replacement) {
-  if (arguments.length < 3) {
+  if (arguments.length < 3 || utils.anyIsNull(text, regular_expression)) {
     return error.na;
+  }
+  if (utils.anyIsError(text, regular_expression) ||
+    typeof text !== 'string' ||
+    typeof regular_expression !== 'string'
+  ) {
+    return error.value;
   }
   return text.replace(new RegExp(regular_expression), replacement);
 };
 
 exports.REPLACE = function(text, position, length, new_text) {
+  if (utils.anyIsNull(text, position, length, new_text)) {
+    return error.na;
+  }
   position = utils.parseNumber(position);
   length = utils.parseNumber(length);
   if (utils.anyIsError(position, length) ||
@@ -245,6 +279,10 @@ exports.REPLACE = function(text, position, length, new_text) {
 };
 
 exports.REPT = function(text, number) {
+  if (text === null) {
+    return error.na;
+  }
+
   number = utils.parseNumber(number);
   if (number instanceof Error) {
     return number;
@@ -253,6 +291,10 @@ exports.REPT = function(text, number) {
 };
 
 exports.RIGHT = function(text, number) {
+  if (text === null) {
+    return error.na;
+  }
+
   number = (number === undefined) ? 1 : number;
   number = utils.parseNumber(number);
   if (number instanceof Error) {
@@ -263,20 +305,27 @@ exports.RIGHT = function(text, number) {
 
 exports.SEARCH = function(find_text, within_text, position) {
   var foundAt;
+  if (utils.anyIsNull(find_text, within_text)) {
+    return error.na;
+  }
   if (typeof find_text !== 'string' || typeof within_text !== 'string') {
     return error.value;
   }
   position = (position === undefined) ? 0 : position;
-  foundAt = within_text.toLowerCase().indexOf(find_text.toLowerCase(), position - 1)+1;
-  return (foundAt === 0)?error.value:foundAt;
+  foundAt = within_text.toLowerCase()
+    .indexOf(find_text.toLowerCase(), position - 1) + 1;
+  return (foundAt === 0) ? error.value : foundAt;
 };
 
 exports.SPLIT = function (text, separator) {
+  if (utils.anyIsNull(text, separator)) {
+    return error.na;
+  }
   return text.split(separator);
 };
 
 exports.SUBSTITUTE = function(text, old_text, new_text, occurrence) {
-  if (arguments.length < 2) {
+  if (arguments.length < 2 || text === null) {
     return error.na;
   }
   if (!text || !old_text || !new_text) {
@@ -294,6 +343,7 @@ exports.SUBSTITUTE = function(text, old_text, new_text, occurrence) {
       }
     }
   }
+  return error.error;
 };
 
 exports.T = function(value) {
@@ -315,6 +365,9 @@ exports.TEXT = function(value, format) {
 };
 
 exports.TRIM = function(text) {
+  if (text === null) {
+    return error.na;
+  }
   if (typeof text !== 'string') {
     return error.value;
   }
@@ -326,6 +379,9 @@ exports.UNICHAR = exports.CHAR;
 exports.UNICODE = exports.CODE;
 
 exports.UPPER = function(text) {
+  if (text === null) {
+    return error.na;
+  }
   if (typeof text !== 'string') {
     return error.value;
   }
@@ -333,10 +389,14 @@ exports.UPPER = function(text) {
 };
 
 exports.VALUE = function(text) {
+  if (text === null) {
+    return error.na;
+  }
+
   if (typeof text !== 'string') {
     return error.value;
   }
   var result = numbro().unformat(text);
 
-  return result === void 0 ? 0 : result;
+  return result === undefined ? 0 : result;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -103,7 +103,7 @@ exports.parseBool = function(bool) {
 };
 
 exports.parseNumber = function(string) {
-  if (string === undefined || string === '') {
+  if (string === undefined || string === '' || string === null) {
     return error.value;
   }
   if (!isNaN(string)) {
@@ -155,11 +155,17 @@ exports.parseMatrix = function(matrix) {
 
 var d1900 = new Date(1900, 0, 1);
 exports.parseDate = function(date) {
+  if (date === undefined || date === '' || date === null) {
+    return error.value;
+  }
   if (!isNaN(date)) {
     if (date instanceof Date) {
       return new Date(date);
     }
     var d = parseInt(date, 10);
+    if (isNaN(d)) {
+      return error.value;
+    }
     if (d < 0) {
       return error.num;
     }
@@ -194,6 +200,16 @@ exports.anyIsError = function() {
   var n = arguments.length;
   while (n--) {
     if (arguments[n] instanceof Error) {
+      return true;
+    }
+  }
+  return false;
+};
+
+exports.anyIsNull = function() {
+  var n = arguments.length;
+  while (n--) {
+    if (arguments[n] === null) {
       return true;
     }
   }
@@ -257,12 +273,12 @@ exports.arrayEach = function(array, iteratee) {
 };
 
 exports.transpose = function(matrix) {
-  if(!matrix) { 
+  if(!matrix) {
     return error.value;
   }
 
-  return matrix[0].map(function(col, i) { 
-    return matrix.map(function(row) { 
+  return matrix[0].map(function(col, i) {
+    return matrix.map(function(row) {
       return row[i];
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -319,14 +319,6 @@
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
-    "bessel": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/bessel/-/bessel-0.2.0.tgz",
-      "integrity": "sha1-E8s5zSkjMhnsLacl4LoMZvtGtvI=",
-      "requires": {
-        "voc": "^1.1.0"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -5195,11 +5187,6 @@
       "requires": {
         "indexof": "0.0.1"
       }
-    },
-    "voc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/voc/-/voc-1.1.0.tgz",
-      "integrity": "sha512-fthgd8OJLqq8vPcLjElTk6Rcl2e3v5ekcXauImaqEnQqd5yUWKg1+ZOBgS2KTWuVKcuvZMQq4TDptiT1uYddUA=="
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "release": "generate-release"
   },
   "dependencies": {
-    "bessel": "^0.2.0",
     "jStat": "^1.7.0",
     "moment": "^2.21.0",
     "numbro": "^1.11.0"

--- a/test/engineering.js
+++ b/test/engineering.js
@@ -3,27 +3,6 @@ var error = require('../lib/error');
 var engineering = require('../lib/engineering');
 
 describe('Engineering', function() {
-  it('BESSELI', function() {
-    engineering.BESSELI(1.5, 1).should.approximately(0.981666, 10e-6);
-    engineering.BESSELI(1.5, 2).should.approximately(0.337835, 10e-6);
-    engineering.BESSELI('invalid').should.equal(error.value);
-  });
-
-  it('BESSELJ', function() {
-    engineering.BESSELJ(1.9, 2).should.approximately(0.329926, 10e-6);
-    engineering.BESSELJ('invalid').should.equal(error.value);
-  });
-
-  it('BESSELK', function() {
-    engineering.BESSELK(1.5, 1).should.approximately(0.277388, 10e-6);
-    engineering.BESSELK('invalid').should.equal(error.value);
-  });
-
-  it('BESSELY', function() {
-    engineering.BESSELY(2.5, 1).should.approximately(0.145918, 10e-6);
-    engineering.BESSELY('invalid').should.equal(error.value);
-  });
-
   it('BIN2DEC', function() {
     engineering.BIN2DEC(1100100).should.equal(100);
     engineering.BIN2DEC(1111111111).should.equal(-1);

--- a/test/utils.js
+++ b/test/utils.js
@@ -96,4 +96,12 @@ describe('Utils', function() {
     utils.transpose([[1,2,3,4],[5,6,7,8], [9,10,11,12]])
       .should.deepEqual([[1,5,9],[2,6,10], [3,7,11], [4,8,12]]);
   });
+
+  it('anyIsNull', function() {
+    should.equal(utils.anyIsNull(), false);
+    should.equal(utils.anyIsNull(0, 'one'), false);
+    should.equal(utils.anyIsNull(null), true);
+    should.equal(utils.anyIsNull(null, 42), true);
+    should.equal(utils.anyIsNull(42, null, 'one'), true);
+  });
 });


### PR DESCRIPTION
In Excel, functions that expect a value but instead receive no value
give the `N/A` error. The text functions in package.js were not
checking for `null` values, so all sorts of errors were resulting. This
commit adds checks for `null` to all functions that take a text input
and did not have that check.

Adds a utility function `isAnyNull`.

Bessel functions are not officially supported (they are not listed in
the Zendesk documents), so those were removed.

Minor linter cleanup.