### PR TITLE
EX-2465 Parse utils give error when passed null

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,6 +72,10 @@ exports.cleanFloat = function(number) {
 };
 
 exports.parseBool = function(bool) {
+  if (bool === null) {
+    return error.na;
+  }
+
   if (typeof bool === 'boolean') {
     return bool;
   }
@@ -103,7 +107,10 @@ exports.parseBool = function(bool) {
 };
 
 exports.parseNumber = function(string) {
-  if (string === undefined || string === '' || string === null) {
+  if (string === null) {
+    return error.na;
+  }
+  if (string === undefined || string === '') {
     return error.value;
   }
   if (!isNaN(string)) {
@@ -114,6 +121,9 @@ exports.parseNumber = function(string) {
 };
 
 exports.parseNumberArray = function(arr) {
+  if (arr === null) {
+    return error.na;
+  }
   var len;
 
   if (!arr || (len = arr.length) === 0) {
@@ -134,6 +144,9 @@ exports.parseNumberArray = function(arr) {
 };
 
 exports.parseMatrix = function(matrix) {
+  if (matrix === null) {
+    return error.na;
+  }
   var n;
 
   if (!matrix || (n = matrix.length) === 0) {
@@ -155,7 +168,10 @@ exports.parseMatrix = function(matrix) {
 
 var d1900 = new Date(1900, 0, 1);
 exports.parseDate = function(date) {
-  if (date === undefined || date === '' || date === null) {
+  if (date === null) {
+    return error.na;
+  }
+  if (date === undefined || date === '') {
     return error.value;
   }
   if (!isNaN(date)) {
@@ -184,6 +200,9 @@ exports.parseDate = function(date) {
 };
 
 exports.parseDateArray = function(arr) {
+  if (arr === null) {
+    return error.na;
+  }
   var len = arr.length;
   var parsed;
   while (len--) {


### PR DESCRIPTION
Changes the parseX functions (date, string, etc) to return `error.na`
when passed a null value. The error is then handled as usual by the
caller.